### PR TITLE
EK-399 Add capitalize_label_type callback

### DIFF
--- a/app/models/spree/label.rb
+++ b/app/models/spree/label.rb
@@ -12,11 +12,17 @@ module Spree
     validate :no_overlapping_validity_dates
     validate :validate_color_format
 
+    before_validation :capitalize_label_type
+
     def always_active
       end_date.nil?
     end
 
     private
+
+    def capitalize_label_type
+      self.label_type = label_type.capitalize if label_type.present?
+    end
 
     def end_date_after_start_date
       return if always_active

--- a/spec/controllers/spree/admin/labels_controller_spec.rb
+++ b/spec/controllers/spree/admin/labels_controller_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe Spree::Admin::LabelsController, type: :controller do
     context 'with valid params' do
       it 'creates a new Label with the correct label_type' do
         valid_attributes[:label_type] = 'other'
-        valid_attributes[:custom_label_type] = 'Custom Type'
+        valid_attributes[:custom_label_type] = 'Custom type'
 
         expect { post :create, params: { label: valid_attributes } }.to change(Spree::Label, :count).by(1)
-        expect(Spree::Label.last.label_type).to eq('Custom Type')
+        expect(Spree::Label.last.label_type).to eq('Custom type')
         expect(response).to redirect_to(admin_labels_path)
         expect(flash[:success]).to eq(I18n.t('spree.admin.label.created'))
       end
@@ -78,10 +78,10 @@ RSpec.describe Spree::Admin::LabelsController, type: :controller do
   describe 'PATCH #update' do
     context 'with valid params' do
       it 'updates the label with the correct label_type' do
-        patch :update, params: { id: label.id, label: { label_type: 'other', custom_label_type: 'Custom Type' } }
+        patch :update, params: { id: label.id, label: { label_type: 'other', custom_label_type: 'Custom type' } }
         label.reload
 
-        expect(label.label_type).to eq('Custom Type')
+        expect(label.label_type).to eq('Custom type')
         expect(response).to redirect_to(admin_labels_path)
         expect(flash[:success]).to eq(I18n.t('spree.admin.label.updated'))
       end

--- a/spec/models/spree/label_spec.rb
+++ b/spec/models/spree/label_spec.rb
@@ -148,4 +148,27 @@ RSpec.describe Spree::Label, type: :model do
       expect(label.always_active).to eq(false)
     end
   end
+
+  describe '#capitalize_label_type' do
+    it 'capitalizes label_type before validation' do
+      label = build(:label, label_type: 'test type')
+
+      expect(label).to be_valid
+      expect(label.label_type).to eq('Test type')
+    end
+
+    it 'does not change label_type if it is already capitalized' do
+      label = build(:label, label_type: 'Test type')
+
+      expect(label).to be_valid
+      expect(label.label_type).to eq('Test type')
+    end
+
+    it 'handles nil label_type gracefully' do
+      label = build(:label, label_type: nil)
+
+      expect(label).to be_invalid
+      expect(label.label_type).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
See: [EK-399](https://yesbizuteria.atlassian.net/browse/EK-399)

Description:
Brakuje jeszcze walidacji dla ciągu znaków, która wykryje, że label_type “new” i “New” i “nEw” to to samo